### PR TITLE
Make vim-projectlocal work with Powerline

### DIFF
--- a/autoload/projectlocal.vim
+++ b/autoload/projectlocal.vim
@@ -1,4 +1,4 @@
 augroup projectlocal "{
 	autocmd!
-	autocmd BufNewFile,BufReadPost * call projectlocal#WalkTree()
+	autocmd BufNewFile,BufReadPost * nested call projectlocal#WalkTree()
 augroup END " }


### PR DESCRIPTION
When editing a new file, [Powerline](https://github.com/Lokaltog/powerline) loses its colours, as demonstrated in [this issue](https://github.com/Lokaltog/powerline/issues/230).

It seems that Powerline doesn't like it when you [resource .vimrc with autocmd](https://github.com/Lokaltog/powerline/issues/213#issuecomment-13507048), because the `ColorScheme` event [isn't fired](https://github.com/Lokaltog/powerline/issues/230#issuecomment-13689589).

The fix is to use [autocmd-nested](http://vimpluginloader.sourceforge.net/doc/autocmd.txt.html#autocmd-nested).
